### PR TITLE
优化在下载文件夹时候的进度条显示

### DIFF
--- a/api_file_download.go
+++ b/api_file_download.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/schollz/progressbar/v3"
@@ -147,7 +148,7 @@ func downloadURL(url string, filename string, showProgressBar bool) error {
 	if showProgressBar {
 		bar := progressbar.DefaultBytes(
 			resp.ContentLength,
-			"downloading",
+			path.Base(filename),
 		)
 
 		if _, err := io.Copy(io.MultiWriter(f, bar), resp.Body); err != nil {


### PR DESCRIPTION
展示每个文件的文件名，不然进度条都是一样的，不知道下载了哪些文件
![image](https://user-images.githubusercontent.com/10371891/151136821-2ec496a2-9d3f-4574-919f-d4b70c06cd6a.png)
