### PR TITLE
增加使用 refresh_token 登录的函数

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 2
+
+[{Makefile, Dockerfile}]
+indent_style = tab
+indent_size = 4
+
+[{*.yml, *.json}]
+indent_style = space
+indent_size = 2

--- a/_examples/all.go
+++ b/_examples/all.go
@@ -14,7 +14,9 @@ func main() {
 	ctx := context.Background()
 
 	// 扫码登录
-	user, err := r.Auth.LoginByQrcode(ctx)
+	user, err := r.Auth.LoginByQrcode(ctx, &aliyundrive.LoginByQrcodeReq{
+		SmallQrCode: true,
+	})
 	assert(err)
 
 	fmt.Println("user:", jsonString(user))

--- a/api_auth_login.go
+++ b/api_auth_login.go
@@ -57,8 +57,7 @@ func (r *AuthService) LoginByRefreshToken(ctx context.Context, refreshToken stri
 		return nil, err
 	}
 
-	err = r.cli.store.Set(ctx, token.Token())
-	if err != nil {
+	if err = r.cli.store.Set(ctx, token.Token()); err != nil {
 		return nil, err
 	}
 

--- a/api_auth_login.go
+++ b/api_auth_login.go
@@ -48,6 +48,23 @@ func (r *AuthService) GetToken(ctx context.Context) (*Token, error) {
 	return token, nil
 }
 
+func (r *AuthService) LoginByRefreshToken(ctx context.Context, refreshToken string) (*GetSelfUserResp, error) {
+	token, err := r.RefreshToken(ctx, &RefreshTokenReq{
+		RefreshToken: refreshToken,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.cli.store.Set(ctx, token.Token())
+	if err != nil {
+		return nil, err
+	}
+
+	return r.GetSelfUser(ctx)
+}
+
 func (r *AuthService) LoginByQrcode(ctx context.Context, request *LoginByQrcodeReq) (*GetSelfUserResp, error) {
 	userInfo, err := r.GetSelfUser(ctx)
 	if IsTokenExpired(err) {

--- a/api_auth_login.go
+++ b/api_auth_login.go
@@ -39,10 +39,19 @@ type LoginByQrcodeReq struct {
 	SmallQrCode bool
 }
 
+func (r *AuthService) GetToken(ctx context.Context) (*Token, error) {
+	token, err := r.cli.store.Get(ctx, "")
+	if err != nil || token.RefreshToken == "" {
+		return nil, err
+	}
+
+	return token, nil
+}
+
 func (r *AuthService) LoginByQrcode(ctx context.Context, request *LoginByQrcodeReq) (*GetSelfUserResp, error) {
 	userInfo, err := r.GetSelfUser(ctx)
 	if IsTokenExpired(err) {
-		token, err := r.cli.store.Get(ctx, "")
+		token, err := r.GetToken(ctx)
 		if err != nil {
 			r.cli.log(ctx, LogLevelError, "get user failed, then get store failed: %s", err)
 		} else if token.RefreshToken != "" {

--- a/api_auth_login_test.go
+++ b/api_auth_login_test.go
@@ -1,0 +1,25 @@
+package aliyundrive
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthService_LoginByRefreshToken(t *testing.T) {
+	RefreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
+	if !empty {
+		return
+	}
+
+	cli := New()
+
+	// 获取 refresh_token 可以通过网页端： JSON.parse(localStorage.token).refresh_token
+	userInfo, err := cli.Auth.LoginByRefreshToken(context.TODO(), RefreshToken)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, userInfo)
+	assert.NotEmpty(t, userInfo.UserID)
+}

--- a/api_auth_login_test.go
+++ b/api_auth_login_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAuthService_LoginByRefreshToken(t *testing.T) {
-	RefreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
+	refreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
 	if !empty {
 		return
 	}
@@ -17,7 +17,7 @@ func TestAuthService_LoginByRefreshToken(t *testing.T) {
 	cli := New()
 
 	// 获取 refresh_token 可以通过网页端： JSON.parse(localStorage.token).refresh_token
-	userInfo, err := cli.Auth.LoginByRefreshToken(context.TODO(), RefreshToken)
+	userInfo, err := cli.Auth.LoginByRefreshToken(context.TODO(), refreshToken)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, userInfo)

--- a/api_auth_refresh_token_test.go
+++ b/api_auth_refresh_token_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAuthService_RefreshToken(t *testing.T) {
-	RefreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
+	refreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
 	if !empty {
 		return
 	}
@@ -18,7 +18,7 @@ func TestAuthService_RefreshToken(t *testing.T) {
 
 	// 获取 refresh_token 可以通过网页端： JSON.parse(localStorage.token).refresh_token
 	token, err := cli.Auth.RefreshToken(context.TODO(), &RefreshTokenReq{
-		RefreshToken: RefreshToken,
+		RefreshToken: refreshToken,
 	})
 
 	assert.NoError(t, err)

--- a/api_auth_refresh_token_test.go
+++ b/api_auth_refresh_token_test.go
@@ -1,0 +1,27 @@
+package aliyundrive
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthService_RefreshToken(t *testing.T) {
+	RefreshToken, empty := os.LookupEnv("REFRESH_TOKEN")
+	if !empty {
+		return
+	}
+
+	cli := New()
+
+	// 获取 refresh_token 可以通过网页端： JSON.parse(localStorage.token).refresh_token
+	token, err := cli.Auth.RefreshToken(context.TODO(), &RefreshTokenReq{
+		RefreshToken: RefreshToken,
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.NotEmpty(t, token.RefreshToken)
+}


### PR DESCRIPTION
以及对应的用例测试

@TODO 分离保存 token 的方式，例如支持使用 redis 等中间件